### PR TITLE
Fix file upload for python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ PyJWT==1.4.0
 # Utilities
 six==1.10.0
 boto==2.39.0
-unicodecsv==0.14.1
 Markdown==2.6.6
 bleach==1.4.2
 python-dateutil==2.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ python-social-auth==0.2.14
 requests==2.9.1
 requests-oauthlib==0.6.1
 oauthlib==1.0.3
-python-openid==2.2.5
+python3-openid==3.0.10
 PyJWT==1.4.0
 
 # Utilities


### PR DESCRIPTION
- file uploads were broken b/c  django model FileField returns bytes stream, and csv parser expects string stream
- fixed by decoding first line of file into string
- refactored signals & models of DataFile to have same code in just one place (models method read_csv_headers now is used in signals)
- dropped unicodecsv b/c it was used for unicode string handling in py2